### PR TITLE
fix: adding roles/storage.objectViewer and enabling library scanning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,9 +39,15 @@ resource "google_project_service" "required_apis_for_gar_integration" {
 }
 
 // Role(s) for a GAR integration
-resource "google_project_iam_member" "for_gar_integration" {
+resource "google_project_iam_member" "gar_reader" {
   project = local.project_id
   role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${local.service_account_json_key.client_email}"
+}
+
+resource "google_project_iam_member" "storage_reader" {
+  project = local.project_id
+  role    = "roles/storage.objectViewer"
   member  = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 
@@ -52,7 +58,8 @@ resource "time_sleep" "wait_time" {
   depends_on = [
     module.lacework_gar_svc_account,
     google_project_service.required_apis_for_gar_integration,
-    google_project_iam_member.for_gar_integration
+    google_project_iam_member.gar_reader,
+    google_project_iam_member.storage_reader
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,6 @@ variable "limit_num_imgs" {
 
 variable "non_os_package_support" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether or not the integration should check non-os packages in the container for vulnerabilities"
 }


### PR DESCRIPTION
This PR aims to add the `roles/storage.objectViewer` privilege that seems to be required for Lacework to properly enumerate the docker v2 catalog from a Google Artifact Repository.  It also enables library scanning by default to fall in line with the new defaults in Lacework.