### PR TITLE
ci: fix example/default google version constraint

### DIFF
--- a/examples/configure-lacework-gar-integration/versions.tf
+++ b/examples/configure-lacework-gar-integration/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    google = "~> 3.0"
+    google = ">= 3.0.0"
     lacework = {
       source = "lacework/lacework"
     }

--- a/examples/default/versions.tf
+++ b/examples/default/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    google = "~> 3.0"
+    google = ">= 3.0.0"
     lacework = {
       source = "lacework/lacework"
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-gcp-gar/blob/main/CONTRIBUTING.md
--->

## Summary
Failure during release:
```
╷                                                                                                                                                                                                                                                  
│ Error: Failed to query available provider packages                                                                                                                                                                                               
│                                                                                                                                                                                                                                                  
│ Could not retrieve the list of available versions for provider hashicorp/google: no available releases match the given constraints >= 3.0.0, ~> 3.0, >= 4.4.0, < 5.0.0                                                                           
╵                          
```

## How did you test this change?

Running CI

## Issue
N/A