### PR TITLE
fix: empty project_id in google_project data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   resource_level = "PROJECT"
-  project_id     = data.google_project.selected.project_id
+  project_id     = length(var.project_id) > 0 ? var.project_id : data.google_project.selected.project_id
   service_account_name = var.use_existing_service_account ? (
     var.service_account_name
     ) : (
@@ -18,9 +18,7 @@ resource "random_id" "uniq" {
   byte_length = 4
 }
 
-data "google_project" "selected" {
-  project_id = var.project_id
-}
+data "google_project" "selected" {}
 
 module "lacework_gar_svc_account" {
   source               = "lacework/service-account/gcp"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    google = ">= 3.0.0, < 4.41.0"
+    google = ">= 4.4.0, < 5.0.0"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
## Summary

A validation change hashicorp/terraform-provider-google#12846 was introduced in version `4.42.0` of the google provider. This validation makes all our GCP modules to fail with:
```
│ Error: "" project_id must be 6 to 30 with lowercase letters, digits, hyphens and start with a letter. Trailing hyphens are prohibited.
│
│   with module.gcp_project_gar.data.google_project.selected,
│   on .terraform/modules/gcp_project_gar/main.tf line 96, in data "google_project" "selected":
│   96:   project_id = var.project_id
```

To solve this issue we are avoiding using the `google_project` data source when we know the `project_id` that was provided by the user.

If the user does not provide a `project_id`, then we use the data source to discover the project from the google provider.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

Test should pass, plus we will test this in our private Terraform project https://github.com/lacework/terraform-customerdemo

## Issue

- https://lacework.atlassian.net/browse/RAIN-39458
- https://lacework.atlassian.net/browse/RAIN-37109
